### PR TITLE
fix: add buffer-length check in gif.c

### DIFF
--- a/browser/libnsgif/src/gif.c
+++ b/browser/libnsgif/src/gif.c
@@ -311,6 +311,10 @@ static void nsgif__record_frame(
 		return;
 	}
 
+	if (height == 0 || width > SIZE_MAX / pixel_bytes / height) {
+		return;
+	}
+
 	if (gif->prev_frame == NULL) {
 		prev_frame = realloc(gif->prev_frame,
 				width * height * pixel_bytes);


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `browser/libnsgif/src/gif.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `browser/libnsgif/src/gif.c:315` |
| **CWE** | CWE-120 |

**Description**: The GIF decoder performs memcpy operations at lines 324 and 339 using `width * height * pixel_bytes` as the size parameter. These values are derived from attacker-controlled GIF file headers. The multiplication can overflow on 32-bit systems, resulting in a small allocation via realloc but a large copy via memcpy, causing a heap buffer overflow with attacker-controlled data.

## Changes
- `browser/libnsgif/src/gif.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
